### PR TITLE
Fix for matplotlib import error for systems without TkInter installed.

### DIFF
--- a/dynaphopy/__init__.py
+++ b/dynaphopy/__init__.py
@@ -1,6 +1,8 @@
 __version__ = '1.15.4'
 
 import numpy as np
+import matplotlib
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 
 import dynaphopy.projection as projection


### PR DESCRIPTION
importing `matplotlib` on systems that do not have TkInter installed gives a `ModuleNotFoundError` (see https://github.com/matplotlib/matplotlib/issues/9017)
This commit works around this issue by setting the `'agg'` backend for matplotlib.